### PR TITLE
quick fix for missing grunt info

### DIFF
--- a/pogodata/pogodata.py
+++ b/pogodata/pogodata.py
@@ -315,7 +315,7 @@ class PogoData:
         for templateid, entry in self.get_gamemaster(r"^CHARACTER_.*", "invasionNpcDisplaySettings"):
             id_ = enums.get(templateid, 0)
 
-            grunt_info = info_grunts.get(str(id_))
+            grunt_info = info_grunts.get(str(id_), {})
             team = []
             if grunt_info:
                 for i, team_position in enumerate(grunt_info.get("lineup", {}).get("team", [])):


### PR DESCRIPTION
Reloading during Kanto Tour gave me a
```
Traceback (most recent call last):
...
  File "...\venv\lib\site-packages\pogodata\pogodata.py", line 43, in __init__
    self.reload()
  File "...\venv\lib\site-packages\pogodata\pogodata.py", line 93, in reload
    self.__make_grunt_list()
  File "...\venv\lib\site-packages\pogodata\pogodata.py", line 340, in __make_grunt_list
    grunt = Grunt(id_, templateid, entry, grunt_info, team)
  File "...\venv\lib\site-packages\pogodata\objects.py", line 52, in __init__
    self.active = pogoinfo_data.get("active", False)
AttributeError: 'NoneType' object has no attribute 'get'
```

Adding a default value for info_grunts.get() fixes that.